### PR TITLE
feat: Add support for 2D coordinates in mapflow

### DIFF
--- a/mapflow/_plot.py
+++ b/mapflow/_plot.py
@@ -259,11 +259,12 @@ def plot_da(da: xr.DataArray, x_name=None, y_name=None, crs=4326, **kwargs):
     actual_x_name = guess_coord_name(da.coords, X_NAME_CANDIDATES, x_name, "x")
     actual_y_name = guess_coord_name(da.coords, Y_NAME_CANDIDATES, y_name, "y")
 
-    da = da.sortby(actual_x_name).sortby(actual_y_name)
+    if da[actual_x_name].ndim == 1 and da[actual_y_name].ndim == 1:
+        da = da.sortby(actual_x_name).sortby(actual_y_name)
     crs_ = process_crs(da, crs)
     if crs_.is_geographic:
         da[actual_x_name] = xr.where(da[actual_x_name] > 180, da[actual_x_name] - 360, da[actual_x_name])
 
-    p = PlotModel(x=da[actual_x_name].values, y=da[actual_y_name].values, crs=crs)
+    p = PlotModel(x=da[actual_x_name].values, y=da[actual_y_name].values, crs=crs_)
     data = p._process_data(da.values)
     p(data, **kwargs)


### PR DESCRIPTION
The `animate` and `plot_da` functions were previously designed to work only with xarray DataArrays that have 1D coordinates that are also dimensions. This prevented them from working with data on non-rectilinear grids where longitude and latitude are 2D variables.

This commit refactors the coordinate handling logic in `mapflow._animate.py` and `mapflow._plot.py`.

- The `check_da` function in `_animate.py` now detects whether the spatial coordinates are 1D or 2D.
    - If 1D, it sorts by the coordinates as before.
    - If 2D, it skips sorting by coordinates and instead ensures the data is transposed to the correct dimension order (`time`, `y_dim`, `x_dim`).
- The `plot_da` function in `_plot.py` is updated with similar logic to avoid sorting by 2D coordinates.
- The `crs_` variable is now correctly passed to `PlotModel` in `plot_da`.

These changes fix the failing `test_animate_2d` test case and enable `mapflow` to generate animations and plots from data with 2D spatial coordinates.